### PR TITLE
Use the (active) node-swig/swig-templates fork

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var swig = require('swig');
+var swig = require('swig-templates');
 var extras = require('swig-extras');
-var forTag = require('swig/lib/tags/for');
+var forTag = require('swig-templates/lib/tags/for');
 
 extras.useTag(swig, 'markdown');
 extras.useTag(swig, 'switch');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "license": "MIT",
   "dependencies": {
-    "swig": "^1.4.2",
+    "swig-templates": "^2.0.0",
     "swig-extras": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves the following npm warning:

    npm WARN deprecated swig@1.4.2: This package is no longer maintained

This done by depending on the active node-swig/swig-templates.

I'm aware that this project still depends on the original swig-extras however swig is only a dev-dependency of swig-extras so this does not cause a deprecation warning. Therefore I think this PR is still a move in the right direction.

I have raised a PR on node-swig/swig-extras#1 to migrate the swig-extras fork to node-swig/swig-templates so this project can also be migrated away from the old swig-extras once the node-swig/swig-extras package is published.
