### PR TITLE
refactor: avoid using arguments object

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -23,25 +23,21 @@ swig.setDefaults({
 });
 
 // Hack: Override for tag of Swig
-swig.setTag('for', forTag.parse, function(compiler, args, content, parents, options, blockName) {
-  const compile = forTag.compile.apply(this, arguments).split('\n');
+swig.setTag('for', forTag.parse, (...args) => {
+  const compile = forTag.compile(...args).split('\n');
 
   compile.splice(3, 0, '  if (!Array.isArray(__l) && typeof __l.toArray === "function") { __l = __l.toArray(); }');
 
   return compile.join('\n');
 }, forTag.ends, true);
 
-function swigRenderer(data, locals) {
-  return swig.render(data.text, {
-    locals: locals,
-    filename: data.path
+function swigRenderer({ text, path }, locals) {
+  return swig.render(text, {
+    locals,
+    filename: path
   });
 }
 
-swigRenderer.compile = function(data, locals) {
-  return swig.compile(data.text, {
-    filename: data.path
-  });
-};
+swigRenderer.compile = ({ text, path }) => swig.compile(text, { filename: path });
 
 module.exports = swigRenderer;


### PR DESCRIPTION
Hexo will remove built-in swig renderer in https://github.com/hexojs/hexo/pull/2903, which means users are required to install `hexo-swig-renderer` to continue using their current theme.

This PR port Hexo's `swig.js` back to `hexo-renderer-swig` for further usage.